### PR TITLE
Package rn-image-transform.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Generate an SVG or PNG image of a React Native Component Tree",
   "main": "build/index.js",
   "files": [
-    "build/*"
+    "build/*",
+    "rn-image-transform.js"
   ],
   "author": "Orta Therox <orta.therox@gmail.com> & Art.sy Inc & Jared Forsyth <jared@jaredforsyth.com>",
   "license": "MIT",

--- a/rn-image-transform.js
+++ b/rn-image-transform.js
@@ -7,9 +7,11 @@ module.exports = {
   // the correct images are loaded for components. Essentially
   // require('img1.png') becomes `Object { "testUri": 'path/to/img1.png' }` in
   // the Jest snapshot.
+  // This now uses the current directory ('.') instead of __dirname because
+  // npm run scripts always use the root of the module as the current dir.
   process: (contents, filename) => {
     return `module.exports = {
-      testUri: ${JSON.stringify(path.relative(__dirname, filename))}
+      testUri: ${JSON.stringify(path.relative('.', filename))}
     };`
   },
   getCacheKey: createCacheKeyFunction([__filename]),


### PR DESCRIPTION
Right now any project that uses this package needs to manually copy the `rn-image-transform.js` from the git repo into the project and reference it in the `jest` setup.

This diff changes `rn-image-transform.js` so that it calculates image paths relative to the project root rather than relative to the `rn-image-transform.js` file's location. 

It also updates package.json to package `rn-image-transform.js`. 