### PR TITLE
Fixups

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "build": "tsc",
     "test": "jest",
     "watch": "tsc --watch",
-    "prepublish": "npm run build",
-    "lint": "tslint 'src/**/*.{ts,tsx}'"
+    "lint": "tslint '{src,jest}/**/*.{ts,tsx}'",
+    "prepack": "npm run build"
   },
   "lint-staged": {
     "*.@(ts|tsx)": [

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -17,7 +17,7 @@ export interface Component {
 export interface RenderedComponent {
     type: string
     props: any
-    textContent: string | undefined
+    textContent?: string
     children: RenderedComponent[]
     layout: {
         left: number


### PR DESCRIPTION
* Use `prepack` instead of `prepublish` (then `npm pack` can be used to text packaging before publishing)
* Include `jest` directory in tslint
* Make `textContext` optional instead of being a union with `undefined` (the [TypeScript 3 upgrade](https://github.com/jaredly/render-react-native-to-image/pull/2) will needs)